### PR TITLE
[OBSDEF-13968] Styles for modal types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@dellstorage/clarity-react": "^1.1.8",
+    "@dellstorage/clarity-react": "^1.1.13",
     "@types/node": "^12.14.1",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dellstorage/dell-design-react-common",
   "description": "Override CSS of Clarity-React components to align it with Dell design standards",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "Apache-2.0",
   "private": false,
   "outDir": "dist",

--- a/src/components/modals/Modals.stories.tsx
+++ b/src/components/modals/Modals.stories.tsx
@@ -10,7 +10,7 @@
 
 import {storiesOf} from "@storybook/react";
 import {State, Store} from "@sambego/storybook-state";
-import {Modal, ModalSize, ModalBody, ModalFooter} from "@dellstorage/clarity-react/modals/Modal";
+import {Modal, ModalSize, ModalBody, ModalFooter, ModalType} from "@dellstorage/clarity-react/modals/Modal";
 import {Button} from "@dellstorage/clarity-react/forms/button";
 import "styles/components/Modals.scss";
 
@@ -35,6 +35,21 @@ const storeExtraLarge = new Store({
 });
 
 const storeCustom = new Store({
+    isOpen: false,
+    closable: true,
+});
+
+const storeTypeDanger = new Store({
+    isOpen: false,
+    closable: true,
+});
+
+const storeTypeWarn = new Store({
+    isOpen: false,
+    closable: true,
+});
+
+const storeTypeInfo = new Store({
     isOpen: false,
     closable: true,
 });
@@ -132,6 +147,60 @@ storiesOf("Modals", module).add("Modal Sizes", () => (
                     </ModalFooter>
                 </Modal>
                 <Button onClick={() => storeCustom.set({isOpen: !storeCustom.get("isOpen")})}>Custom</Button>
+            </State>
+        </div>
+    </div>
+))
+.add("Modal Types", ()=> (
+    <div className="clr-row">
+        <div className="clr-col-12">
+            <State store={storeTypeDanger}>
+                <Modal onClose={() => storeTypeDanger.set({isOpen: false})} title="Medium modal" type={ModalType.DANGER}>
+                    <ModalBody>
+                        <p>Danger Modal Title</p>
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button onClick={() => storeTypeDanger.set({isOpen: false})} link>
+                            CANCEL
+                        </Button>
+                        <Button onClick={() => storeTypeDanger.set({isOpen: false})} primary={true}>
+                            OK
+                        </Button>
+                    </ModalFooter>
+                </Modal>
+                <Button onClick={() => storeTypeDanger.set({isOpen: !storeTypeDanger.get("isOpen")})}>DANGER</Button>
+            </State>
+            <State store={storeTypeWarn}>
+                <Modal onClose={() => storeTypeWarn.set({isOpen: false})} title="Medium modal" type={ModalType.INFO}>
+                    <ModalBody>
+                        <p>Warning Modal Title</p>
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button onClick={() => storeTypeWarn.set({isOpen: false})} link>
+                            CANCEL
+                        </Button>
+                        <Button onClick={() => storeTypeWarn.set({isOpen: false})} primary={true}>
+                            OK
+                        </Button>
+                    </ModalFooter>
+                </Modal>
+                <Button onClick={() => storeTypeWarn.set({isOpen: !storeTypeWarn.get("isOpen")})}>INFO</Button>
+            </State>
+            <State store={storeTypeInfo}>
+                <Modal onClose={() => storeTypeInfo.set({isOpen: false})} title="Medium modal" type={ModalType.WARNING}>
+                    <ModalBody>
+                        <p>Info Modal Title</p>
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button onClick={() => storeTypeInfo.set({isOpen: false})} link>
+                            CANCEL
+                        </Button>
+                        <Button onClick={() => storeTypeInfo.set({isOpen: false})} primary={true}>
+                            OK
+                        </Button>
+                    </ModalFooter>
+                </Modal>
+                <Button onClick={() => storeTypeInfo.set({isOpen: !storeTypeInfo.get("isOpen")})}>WARNING</Button>
             </State>
         </div>
     </div>

--- a/src/styles/common/_mixins.scss
+++ b/src/styles/common/_mixins.scss
@@ -207,3 +207,10 @@
     font-weight:$font-weight-regular;
 }
 
+@mixin modal-type($color) {
+    border-top-style: solid;
+    border-top-width: 8px;
+    border-color: $color;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}

--- a/src/styles/common/_mixins.scss
+++ b/src/styles/common/_mixins.scss
@@ -209,7 +209,7 @@
 @mixin modal-type($color) {
     border-top-style: solid;
     border-top-width: 8px;
-    border-color: $color;
+    border-top-color: $color;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
 }

--- a/src/styles/components/Modals.scss
+++ b/src/styles/components/Modals.scss
@@ -10,8 +10,20 @@
 
 @import "../common/colors";
 @import "../common/fonts";
+@import "../common/mixins";
 
 .modal {
+    .modal-type {
+        &-danger {
+            @include modal-type($red-700);
+        }
+        &-warning {
+            @include modal-type($yellow-300);
+        }
+        &-info {
+            @include modal-type($blue-600);
+        }
+    }
     .modal-content {
         .modal-header {
             & .close {


### PR DESCRIPTION
Added top border to modals according to modals types.

_[Note: One new prop "ModalType" is introduced in clarity-react Modals which is yet to published, and this PR is using that new field hence PR validation is failing. I will re-run the validation once the changes from clarity-react repo are merged/published]_

Storybook:
![stb1](https://user-images.githubusercontent.com/91124044/159887347-53f6477d-559e-4145-877b-b93f2f707591.gif)

Standalone with DDS:
![dds-standalone](https://user-images.githubusercontent.com/91124044/159887541-365d0828-b078-47d8-854e-8b09fb63e5b4.gif)

