### PR TITLE
[OBSDEF-19544, OBSDEF-19546] Fixes for signpost and toggle styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dellstorage/dell-design-react-common",
   "description": "Override CSS of Clarity-React components to align it with Dell design standards",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Apache-2.0",
   "private": false,
   "outDir": "dist",

--- a/src/styles/components/SignPost.scss
+++ b/src/styles/components/SignPost.scss
@@ -18,6 +18,7 @@
         display: inline-flex;
         align-items: flex-start;
         color: $blue-600 !important;
+        overflow: visible;
     }
 
     .btn {

--- a/src/styles/components/SignPost.scss
+++ b/src/styles/components/SignPost.scss
@@ -10,23 +10,48 @@
 @import "../common/colors";
 @import "../common/fonts";
 
+.signpost {
+    font-family: $dell-font;
+    &-action {
+        width: initial;
+        white-space: break-spaces;
+        display: inline-flex;
+        align-items: flex-start;
+        color: $blue-600 !important;
+    }
+
+    .btn {
+        &-link {
+            &:focus {
+                outline: none !important;
+            }
+        }
+
+    }
+}
+
 .signpost-content{
     min-width: 16rem !important;
     color: $gray-900;
 
     .signpost-content-header{
         margin-top: 1rem;
-        padding-left: 0.2rem;
         
         .signpost-heading{
-            font-size: 1rem;
+            font-size: 0.9rem;
             font-weight: $font-weight-regular;
             margin-left: 1rem;
-            padding-right: 4rem;
+            padding-right: 4.9rem;
         }
     
         .signpost-action {
             margin-right: 1rem;
+        }
+
+        .close {
+            &:focus {
+                outline: none;
+            }
         }
     }
     
@@ -34,6 +59,7 @@
         margin-top: 1.2rem;
         margin-bottom: 1rem;
         line-height: 1.25rem;
-        font-size: 0.8rem;
+        font-size: 0.65rem;
+        text-align: left;
     }
 }

--- a/src/styles/components/Toggle.scss
+++ b/src/styles/components/Toggle.scss
@@ -11,8 +11,7 @@
 @import "../common/colors";
 
 .clr-toggle-wrapper {
-    margin-bottom: 0.8rem;
-
+    
     input[type="checkbox"]{
         &:checked{
             & + label::before{

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -40,7 +40,7 @@
 @import "./components/Breadcrumb";
 @import "./components/DoughnutChart";
 @import "./components/SignPost";
-@import "./components/Toggle.scss";
+@import "./components/Toggle";
 
 body {
   margin: 0;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -39,6 +39,8 @@
 @import "./components/FileSelect";
 @import "./components/Breadcrumb";
 @import "./components/DoughnutChart";
+@import "./components/SignPost";
+@import "./components/Toggle.scss";
 
 body {
   margin: 0;


### PR DESCRIPTION
## Summary of the changes 

[OBSDEF-19544](https://jira.cec.lab.emc.com/browse/OBSDEF-19544 )

[OBSDEF-19546](https://jira.cec.lab.emc.com/browse/OBSDEF-19546)

 Fixes for signpost and toggle styles
## Screenshot/GIF
#### Before
https://jira.cec.lab.emc.com/secure/attachment/1033582/image-2022-08-23-18-00-41-774.png

https://jira.cec.lab.emc.com/secure/attachment/1033586/image-2022-08-23-18-12-02-534.png
#### After
![image](https://user-images.githubusercontent.com/91124044/187140406-3ecea312-b399-4f19-b78f-3adb85ffa155.png)

![image](https://user-images.githubusercontent.com/91124044/187140544-c86b39ee-ff4e-4b56-a9d9-eb1c48e73780.png)

![image](https://user-images.githubusercontent.com/91124044/187345913-cb5ab0c4-7fed-45e4-a110-7789d0f71c3a.png)

Tested on vshpere as well doesn't affect existing styles
![image](https://user-images.githubusercontent.com/91124044/187218118-7ee1a8d9-458e-4182-bb86-abcc035abdeb.png)

## Where to test ?
http://10.249.253.4:3007/

`kubeadmin / JbRur-Jca8w-t8GtU-sTtxy`

## Scenarios verified/Documentation link
Signpost
1) The text that opens up the sign post is aligned with other data grid cell items
2) It doesn't overlaps with the other datagrid cell text when the length is more.
3) Color of the text is as per DDS standards.
4) In the expandable section, the signpost text is aligned with other data grid cell items.

Toggle
1) The color of the toggle when enabled  is as per DDS.
2) No unnecessary margins for toggle button

## Verified on Platform(s)
_Select the platforms on which you have verified the changes_
- [x] vSphere plugin
- [x] OpenShift
- [x] Standalone

