### PR TITLE
[OBSDEF-19540] Remove default blue color from is-solid class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dellstorage/dell-design-react-common",
   "description": "Override CSS of Clarity-React components to align it with Dell design standards",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "Apache-2.0",
   "private": false,
   "outDir": "dist",
@@ -12,7 +12,7 @@
     "node": ">=16.14.1"
   },
   "dependencies": {
-    "@dellstorage/clarity-react": "^1.1.20",
+    "@dellstorage/clarity-react": "^1.2.1",
     "@types/node": "^12.14.1",
     "bootstrap": "^5.2.0",
     "react": "^17.0.2",

--- a/src/components/dataGrid/DataGrid.stories.tsx
+++ b/src/components/dataGrid/DataGrid.stories.tsx
@@ -54,7 +54,7 @@ storiesOf("DataGrid", module)
                         filter: (
                             <DataGridFilter
                                 onFilter={filterFunction}
-                                columnName={"Name"}
+                                columnName="Serial"
                                 datagridRef={datagridFilterRef}
                                 position={FilterPosition.CENTER}
                             />
@@ -151,7 +151,7 @@ storiesOf("DataGrid", module)
                         filter: (
                             <DataGridFilter
                                 onFilter={filterFunction}
-                                columnName={"Name"}
+                                columnName="Serial"
                                 datagridRef={datagridFilterSortRef}
                                 position={FilterPosition.CENTER}
                             />
@@ -185,7 +185,7 @@ storiesOf("DataGrid", module)
                             filter: (
                                 <DataGridFilter
                                     onFilter={filterFunction}
-                                    columnName={"Name"}
+                                    columnName="Serial"
                                     datagridRef={datagridFilterRef}
                                     position={FilterPosition.CENTER}
                                 />
@@ -213,7 +213,7 @@ storiesOf("DataGrid", module)
                             filter: (
                                 <DataGridFilter
                                     onFilter={filterFunction}
-                                    columnName={"Name"}
+                                    columnName={"Serial"}
                                     datagridRef={datagridFilterRef}
                                     position={FilterPosition.CENTER}
                                     showFilter={false}

--- a/src/components/dataGrid/DataGridStoriesData.tsx
+++ b/src/components/dataGrid/DataGridStoriesData.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) 2021 - 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -8,10 +8,10 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import React from "react";
 import {DataGridRow, DataGridFilterResult, SortOrder, DataGridColumn} from "@dellstorage/clarity-react/datagrid";
 import {Icon} from "@dellstorage/clarity-react/icon";
 import {Button} from "@dellstorage/clarity-react/forms/button";
-import * as React from "react";
 /**
  * Data for Columns
  */
@@ -196,7 +196,7 @@ export const hideShowColFooter = {
  * Data for Pagination
  */
 
-// Function to get data for page based on pagenumber
+// Function to get data for page based on page number
 export const getPageData = (pageIndex: number, pageSize: number): Promise<DataGridRow[]> => {
     return new Promise((resolve, reject) => {
         let rows: DataGridRow[] = [];
@@ -210,7 +210,7 @@ export const getPageData = (pageIndex: number, pageSize: number): Promise<DataGr
         } else if (pageSize === 10) {
             rows = paginationRows;
         }
-        // Purposefully added dealy here to see loading spinner
+        // Purposefully added delay here to see loading spinner
         setTimeout(function() {
             resolve(rows);
         }, 2000);
@@ -273,27 +273,18 @@ export const paginationDetails = {
     pageSize: 5,
     pageSizes: [5, 10],
 };
+
 /**
  * Data for Filtering
  */
-
- function filterRows(rows: DataGridRow[], columnValues: string[]) {
-    const newRows = rows.filter(row => {
-        let matchFound = false;
-        for (const index in row.rowData) {
-            const content = String(row.rowData[index].cellData);
-            columnValues.forEach(columnValue => {
-                if (content.indexOf(columnValue) !== -1) {
-                    matchFound = true;
-                }
-            });
-        }
-        if (matchFound) {
-            return row;
-        }
-    });
-    return newRows;
-}
+ function filterRows(rows: DataGridRow[], filterColumn: string, columnValues: string[]) {
+     return rows.filter((row) =>
+         row.rowData.some(
+             ({columnName, cellData}) =>
+                 filterColumn === columnName && columnValues.some((value) => cellData.indexOf(value) !== -1),
+         ),
+     );
+ }
 
 
 //Custom function to filter data
@@ -318,7 +309,7 @@ export const filterFunction = (
                 totalItems: normalRows.length,
             };
         } else {
-            const newRows = filterRows(normalRows, Array.isArray(columnValue) ? columnValue : [columnValue]);
+            const newRows = filterRows(normalRows, columnName, Array.isArray(columnValue) ? columnValue : [columnValue]);
             result = {
                 rows: newRows,
                 totalItems: newRows.length,
@@ -335,11 +326,11 @@ export const sortFunction = (rows: DataGridRow[], sortOrder: SortOrder, columnNa
             (first: DataGridRow, second: DataGridRow): number => {
                 let result = 0;
                 let firstRecord = first.rowData.find(function(element: any) {
-                    if (element.columnName === columnName) return element;
+                    return element.columnName === columnName;
                 });
 
                 let secondRecord = second.rowData.find(function(element: any) {
-                    if (element.columnName === columnName) return element;
+                    return element.columnName === columnName;
                 });
 
                 if (firstRecord && secondRecord) {
@@ -352,7 +343,7 @@ export const sortFunction = (rows: DataGridRow[], sortOrder: SortOrder, columnNa
                             if (firstRecord.cellData > secondRecord.cellData) result = -1;
                             else if (firstRecord.cellData < secondRecord.cellData) result = 1;
                         }
-                    } else if (sortOrder == SortOrder.DESC) {
+                    } else if (sortOrder === SortOrder.DESC) {
                         if (contentType === "number") {
                             result = secondRecord.cellData - firstRecord.cellData;
                         } else if (contentType === "string") {

--- a/src/components/dougnutChart/DoughnutChart.tsx
+++ b/src/components/dougnutChart/DoughnutChart.tsx
@@ -8,28 +8,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import React, { useEffect, useState, useRef } from "react";
-
-/**
- * Props for the doughnut chart
- * @param {size} is to get the width or height of the chart (Width and height would be equal in case of this chart). Defaults to 200px.
- * @param {percentage} is to get the percentage of the chart
- * @param {status} is to get the status color for the chart (Success, Warning and Danger). Defaults to "Success".
- * @param {label} is to get the Label to be displayed in the chart.
- * @param {showPercentage} is a boolean value for displaying percentage in label. Defaults to true.
- * @param {trackWidth} is to get the width of the chart's track. Defaults to 15px.
- * @param {labelLength} is an optional prop to get the truncation length of the label provided. Defaults to 15.
- */
-
-export type CircularProgressType = {
-    size?: number;
-    percentage: number;
-    status?: CHART_STATUS;
-    label: string;
-    showPercentage?: boolean;
-    trackWidth?: number;
-    labelLength?: number;
-}
+import React, { useEffect, useState } from "react";
 
 export enum CHART_STATUS {
     SUCCESS = "success",
@@ -50,6 +29,27 @@ export enum DEFAULT_CHART_VALUES {
     LABEL_LENGTH = 15,
     MIN_SIZE = 100,
     MAX_SIZE = 250,
+}
+
+/**
+ * Props for the doughnut chart
+ * @param {size} is to get the width or height of the chart (Width and height would be equal in case of this chart). Defaults to 200px.
+ * @param {percentage} is to get the percentage of the chart
+ * @param {status} is to get the status color for the chart (Success, Warning and Danger). Defaults to "Success".
+ * @param {label} is to get the Label to be displayed in the chart.
+ * @param {showPercentage} is a boolean value for displaying percentage in label. Defaults to true.
+ * @param {trackWidth} is to get the width of the chart's track. Defaults to 15px.
+ * @param {labelLength} is an optional prop to get the truncation length of the label provided. Defaults to 15.
+ */
+
+ export type CircularProgressType = {
+    size?: number;
+    percentage: number;
+    status?: CHART_STATUS;
+    label: string;
+    showPercentage?: boolean;
+    trackWidth?: number;
+    labelLength?: number;
 }
 
 // This offset will move the text with the specified pixels vertically downwards, preventing the overlap of percentage and label text.
@@ -110,7 +110,7 @@ export const DoughnutChart = (props: CircularProgressType) => {
                 setProgressClass(PROGRESS_CLASS.SUCCESS);
         }
 
-    }, [percentage, setOffset, dimensions.circumference, offset, label, showPercentage, trackWidth])
+    }, [status, percentage, setOffset, dimensions.circumference, offset, label, showPercentage, trackWidth])
     return (
         <React.Fragment key={percentage}>
             <svg className="doughnut-chart" width={size} height={size}>

--- a/src/components/layout/nav/Header.stories.tsx
+++ b/src/components/layout/nav/Header.stories.tsx
@@ -8,7 +8,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
- import * as React from "react";
+ import React from "react";
  import {storiesOf} from "@storybook/react";
  import {Header, HeaderColor, Nav, NavLevel, NavLink, NavType} from "@dellstorage/clarity-react/layout/nav";
  import "styles/components/Navigation.scss";
@@ -33,26 +33,26 @@
                      </div>
                  </Header>
                  <Nav navLevel={NavLevel.SECONDARY} navType={NavType.HEADER}>
-                    <a className="nav-link nav-icon-text submenu-navlink">
+                    <span className="nav-link nav-icon-text submenu-navlink">
                         <Icon shape={"dashboard"} className="nav-icon" />
                         <span className="nav-text">{"Dashboard"}</span>
-                    </a>
-                    <a className="nav-link nav-icon-text submenu-navlink active">
+                    </span>
+                    <span className="nav-link nav-icon-text submenu-navlink active">
                         <Icon shape={"storage"} className="nav-icon" />
                         <span className="nav-text">{"Object Stores"}</span> 
-                    </a>
-                    <a className="nav-link nav-icon-text submenu-navlink">
+                    </span>
+                    <span className="nav-link nav-icon-text submenu-navlink">
                         <Icon shape={""} className="" />
                         <span className="nav-text">{"ObjectScale Systems"}</span>
-                    </a>
-                    <a className="nav-link nav-icon-text submenu-navlink">
+                    </span>
+                    <span className="nav-link nav-icon-text submenu-navlink">
                         <Icon shape={"file-settings"} className="nav-icon" />
                         <span className="nav-text">{"Settings"}</span>
-                    </a>
-                    <a className="nav-link nav-icon-text submenu-navlink">
+                    </span>
+                    <span className="nav-link nav-icon-text submenu-navlink">
                         <Icon shape={"form"} className="nav-icon" />
                         <span className="nav-text">{"Summary"}</span>
-                    </a>
+                    </span>
                  </Nav>
              </div>
          </React.Fragment>

--- a/src/components/maincontainer/MainContainer.stories.tsx
+++ b/src/components/maincontainer/MainContainer.stories.tsx
@@ -103,26 +103,26 @@ storiesOf("MainContainer", module)
                     </div>}
                 subNav={
                     <Nav navLevel={NavLevel.SECONDARY} navType={NavType.HEADER}>
-                    <a className="nav-link nav-icon-text submenu-navlink">
+                    <span className="nav-link nav-icon-text submenu-navlink">
                         <Icon shape={"dashboard"} className="nav-icon" />
                         <span className="nav-text">{"Dashboard"}</span>
-                    </a>
-                    <a className="nav-link nav-icon-text submenu-navlink active">
+                    </span>
+                    <span className="nav-link nav-icon-text submenu-navlink active">
                         <Icon shape={"storage"} className="nav-icon" />
                         <span className="nav-text">{"Object Stores"}</span> 
-                    </a>
-                    <a className="nav-link nav-icon-text submenu-navlink">
+                    </span>
+                    <span className="nav-link nav-icon-text submenu-navlink">
                         <Icon shape={""} className="" />
                         <span className="nav-text">{"ObjectScale Systems"}</span>
-                    </a>
-                    <a className="nav-link nav-icon-text submenu-navlink">
+                    </span>
+                    <span className="nav-link nav-icon-text submenu-navlink">
                         <Icon shape={"file-settings"} className="nav-icon" />
                         <span className="nav-text">{"Settings"}</span>
-                    </a>
-                    <a className="nav-link nav-icon-text submenu-navlink">
+                    </span>
+                    <span className="nav-link nav-icon-text submenu-navlink">
                         <Icon shape={"form"} className="nav-icon" />
                         <span className="nav-text">{"Summary"}</span>
-                    </a>
+                    </span>
                  </Nav>
                 }
             >

--- a/src/components/signpost/SignPost.stories.tsx
+++ b/src/components/signpost/SignPost.stories.tsx
@@ -146,7 +146,7 @@ storiesOf("Signposts", module)
             <div style={{float: "left"}}>
                 <SignPost
                     direction={SignPostDirection.RIGHT_MIDDLE}
-                    openAt={<a href="javascript://">Hello</a>}
+                    openAt={<span>Hello</span>}
                     customSignPostTrigger
                     signpostHeading={"Signpost Heading"}
                 >

--- a/src/components/wizard/Wizard.stories.tsx
+++ b/src/components/wizard/Wizard.stories.tsx
@@ -11,7 +11,7 @@
  import React from "react";
  import {storiesOf} from "@storybook/react";
  import Wizard, {WizardSize} from "@dellstorage/clarity-react/newWizard/Wizard";
- import WizardStep, {WizardStepType} from "@dellstorage/clarity-react/newWizard/WizardStep";
+ import WizardStep from "@dellstorage/clarity-react/newWizard/WizardStep";
  import {State} from "@sambego/storybook-state";
  import {Button} from "@dellstorage/clarity-react/forms/button";
  import {Input} from "@dellstorage/clarity-react/forms/input/Input";

--- a/src/styles/components/ToolTip.scss
+++ b/src/styles/components/ToolTip.scss
@@ -15,6 +15,11 @@
 @import "../common/fonts";
 
 .tooltip {
+    .is-solid {
+        &:hover, &:focus {
+            color: $tooltip-icon-color !important;
+        }
+    }
     .tooltip-content {
         @include tooltip-content;
         &::before{

--- a/src/styles/components/ToolTip.scss
+++ b/src/styles/components/ToolTip.scss
@@ -15,9 +15,6 @@
 @import "../common/fonts";
 
 .tooltip {
-    .is-solid {
-        color: $tooltip-icon-color!important;
-    }
     .tooltip-content {
         @include tooltip-content;
         &::before{

--- a/src/styles/components/ToolTip.scss
+++ b/src/styles/components/ToolTip.scss
@@ -15,11 +15,8 @@
 @import "../common/fonts";
 
 .tooltip {
-    .is-solid {
-        &:hover, &:focus {
-            color: $tooltip-icon-color !important;
-        }
-    }
+    color: $tooltip-icon-color;
+
     .tooltip-content {
         @include tooltip-content;
         &::before{

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,10 +1337,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@dellstorage/clarity-react@^1.1.20":
-  version "1.1.20"
-  resolved "https://registry.yarnpkg.com/@dellstorage/clarity-react/-/clarity-react-1.1.20.tgz#87a6de140b964ac066c3c36680d25ea9b34f4bf4"
-  integrity sha512-PNQMFct6PLqAjKgEpQh1er2foaBXHK9iJ8kTLF3M/NzT065tYltejF4bgfB6jkusgGWwZgVq0BqDvK9vIe2txw==
+"@dellstorage/clarity-react@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@dellstorage/clarity-react/-/clarity-react-1.2.1.tgz#c36faddffc307ced3ec78149c566f98669587cde"
+  integrity sha512-bKsT6FUayG88a6XxLIo1VJwL24c82hWQsfpUCIAVYpo1XlMGulc5ryg0b5G3yROh3QXA32ctjutfD4Y6OTwWUQ==
   dependencies:
     "@clr/icons" "12.0.8"
     "@clr/ui" "12.0.8"


### PR DESCRIPTION
## Summary of the changes 
- Remove blue color from the icons if it is having `is-solid` class, it will be filled only now.
- Fix TS lint in console, throughout the storybook
- Fix filtering on datagrid table, using column name
- And update to the latest clarity react version

[OBSDEF-19540](https://jira.cec.lab.emc.com/browse/OBSDEF-19540)

#### Root Cause
Solid class overriding the color and setting it to blue

#### What's the fix?
Remove the color prop from class, is-solid

## Screenshot/GIF'
#### Before
![tslintissues](https://user-images.githubusercontent.com/78294852/192955826-b7c9626e-7dd5-4705-bbf8-53487dff062c.gif)

#### After
![tslintfix](https://user-images.githubusercontent.com/78294852/192955863-f99d14ee-5ed1-4a02-8a48-8365d76560ac.gif)
![Tooltip](https://user-images.githubusercontent.com/78294852/192966192-35426039-0e2c-4c95-80db-e693758a7bc1.gif)

### Where to test
http://10.249.253.4:8008/?path=/story/tooltip--tooltip-customization