### PR TITLE
Bugfix obsdef-19692 Alert text font is bigger than expected.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dellstorage/dell-design-react-common",
   "description": "Override CSS of Clarity-React components to align it with Dell design standards",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "Apache-2.0",
   "private": false,
   "outDir": "dist",

--- a/src/styles/common/_fonts.scss
+++ b/src/styles/common/_fonts.scss
@@ -40,7 +40,8 @@ $input-placeholder-font-size: 0.7rem;
 $radio-button-label-font-size: 0.875rem;
 
 // Alerts
-$alert-font-size: 0.875rem;
+$alert-font-size: 0.7rem;
+$alert-app-level-font-size: 0.875rem;
 $alert-btn-font-size: 0.812rem;
 
 // Badges

--- a/src/styles/components/Alert.scss
+++ b/src/styles/components/Alert.scss
@@ -27,6 +27,7 @@
     }
     &.alert-app-level {
         height: $alert-app-level-height;
+        font-size: $alert-app-level-font-size!important;
         .alert-text {
             flex: 0 1 auto!important;
             .btn {


### PR DESCRIPTION
**Issue:** Alert text font is bigger than expected.
The Alert size (0.875rem) is bigger than the font size in wizards (0.7rem). 
**Fix:** Alert font size reduced to 0.7rem. No change for Global/App Alerts(0.875rem) as it matches with the other 
body/menu font sizes.
Test URL: 
http://10.249.253.4:3001/
kubeadmin/ JbRur-Jca8w-t8GtU-sTtxy
After changes
![Screenshot (814)](https://user-images.githubusercontent.com/87367751/197209981-3eb0bbf7-482d-4f83-8d77-dcf1975f0e33.png)
![Screenshot (816)](https://user-images.githubusercontent.com/87367751/197209993-c36bd4a0-f527-4441-8576-d083df042dbc.png)
![Screenshot (817)](https://user-images.githubusercontent.com/87367751/197210002-1ba53e60-b68c-4734-b974-c3d2ee71a391.png)
![Screenshot (818)](https://user-images.githubusercontent.com/87367751/197210008-12f3c04f-65f4-4ca0-9c15-19b0f3aa45b8.png)


