### PR TITLE
[OBSDEF-24808] Collapsible breadcrumbs functionality

### DIFF
--- a/src/components/breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/breadcrumb/Breadcrumb.stories.tsx
@@ -60,7 +60,7 @@ const defaultBreadcrumbs = [
     },
 ];
 
-const collapsibleBreadcrumbs = (maxItems: number = 3, isCollapsible: boolean = true) => [
+const collapsibleBreadcrumbs = (maxItems: number = 3, isCollapsible?: boolean) => [
     {
         title: `${isCollapsible && maxItems < 4 ? "Collapsible " : ""}Four level Breadcrumb`,
         itemComponent: (
@@ -86,11 +86,8 @@ const collapsibleBreadcrumbs = (maxItems: number = 3, isCollapsible: boolean = t
 ];
 
 storiesOf("Breadcrumb", module)
-    .add("Default Breadcrumbs", () => <Accordion content={defaultBreadcrumbs} />)
-    .add("Uncollapsed Breadcrumbs", () => (
-        <Accordion content={[...defaultBreadcrumbs, ...collapsibleBreadcrumbs(undefined, false)]} />
-    ))
+    .add("Default Breadcrumbs", () => <Accordion content={[...defaultBreadcrumbs, ...collapsibleBreadcrumbs()]} />)
     .add("Collapsible Breadcrumbs with Default (3)", () => (
-        <Accordion content={[...defaultBreadcrumbs, ...collapsibleBreadcrumbs()]} />
+        <Accordion content={[...defaultBreadcrumbs, ...collapsibleBreadcrumbs(undefined, true)]} />
     ))
-    .add("Collapsible Breadcrumbs with maxItems as 4", () => <Accordion content={collapsibleBreadcrumbs(4)} />);
+    .add("Collapsible Breadcrumbs with maxItems as 4", () => <Accordion content={collapsibleBreadcrumbs(4, true)} />);

--- a/src/components/breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/breadcrumb/Breadcrumb.stories.tsx
@@ -8,11 +8,11 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import React from "react";
 import {storiesOf} from "@storybook/react";
-import {Breadcrumbs, BreadcrumbItem} from "./Breadcrumb";
+import {Accordion} from "@dellstorage/clarity-react/accordian";
 import {action} from "@storybook/addon-actions";
 import "styles/components/Breadcrumb.scss";
+import {Breadcrumbs, BreadcrumbItem} from "./Breadcrumb";
 
 const twoLevelBreadcrumbItems: Array<BreadcrumbItem> = [
     {title: "Data Grid with Infinite Scroll", path: "/?path=/story/data-grid-with-infinite-scroll--basic-grid"},
@@ -44,22 +44,53 @@ const singleBreadcrumbItem: Array<BreadcrumbItem> = [
         isActive: true,
     },
 ];
+const defaultBreadcrumbs = [
+    {title: "Single Level Breadcrumb", itemComponent: <Breadcrumbs breadcrumbItems={singleBreadcrumbItem} />},
+    {
+        title: "Two level Breadcrumb",
+        itemComponent: (
+            <Breadcrumbs breadcrumbItems={twoLevelBreadcrumbItems} onClick={action("breadcrumbItem click")} />
+        ),
+    },
+    {
+        title: "Three level Breadcrumb",
+        itemComponent: (
+            <Breadcrumbs breadcrumbItems={threeLevelBreadcrumbItems} onClick={action("breadcrumbItem click")} />
+        ),
+    },
+];
 
-storiesOf("Breadcrumb", module).add("Basic", () => (
-    <React.Fragment>
-        Single Breadcrumb: <Breadcrumbs breadcrumbItems={singleBreadcrumbItem} />
-        <br />
-        Two level Breadcrumbs:{" "}
-        <Breadcrumbs breadcrumbItems={twoLevelBreadcrumbItems} onClick={action("breadcrumbItem click")} />
-        <br />
-        Three level Breadcrumbs:{" "}
-        <Breadcrumbs breadcrumbItems={threeLevelBreadcrumbItems} onClick={action("breadcrumbItem click")} />
-        <br />
-        Four level Breadcrumbs:{" "}
-        <Breadcrumbs breadcrumbItems={fourLevelBreadcrumbItems} onClick={action("breadcrumbItem click")} />
-        <br />
-        Five level Breadcrumbs:{" "}
-        <Breadcrumbs breadcrumbItems={fiveLevelBreadcrumbItems} onClick={action("breadcrumbItem click")} />
-        <br />
-    </React.Fragment>
-));
+const collapsibleBreadcrumbs = (maxItems: number = 3, isCollapsible: boolean = true) => [
+    {
+        title: `${isCollapsible && maxItems < 4 ? "Collapsible " : ""}Four level Breadcrumb`,
+        itemComponent: (
+            <Breadcrumbs
+                breadcrumbItems={fourLevelBreadcrumbItems}
+                onClick={action("breadcrumbItem click")}
+                maxItems={maxItems}
+                isCollapsible={isCollapsible}
+            />
+        ),
+    },
+    {
+        title: `${isCollapsible && maxItems < 5 ? "Collapsible " : ""}Five level Breadcrumb`,
+        itemComponent: (
+            <Breadcrumbs
+                breadcrumbItems={fiveLevelBreadcrumbItems}
+                onClick={action("breadcrumbItem click")}
+                maxItems={maxItems}
+                isCollapsible={isCollapsible}
+            />
+        ),
+    },
+];
+
+storiesOf("Breadcrumb", module)
+    .add("Default Breadcrumbs", () => <Accordion content={defaultBreadcrumbs} />)
+    .add("Uncollapsed Breadcrumbs", () => (
+        <Accordion content={[...defaultBreadcrumbs, ...collapsibleBreadcrumbs(undefined, false)]} />
+    ))
+    .add("Collapsible Breadcrumbs with Default (3)", () => (
+        <Accordion content={[...defaultBreadcrumbs, ...collapsibleBreadcrumbs()]} />
+    ))
+    .add("Collapsible Breadcrumbs with maxItems as 4", () => <Accordion content={collapsibleBreadcrumbs(4)} />);

--- a/src/components/breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) 2022 - 2023 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,50 +44,38 @@ export type BreadcrumbItems = {
     isCollapsible?: boolean;
 };
 
+// Function to create breadcrumbs collapsible or default list
 const getBreadcrumbItems = (
     items: Array<BreadcrumbItem>,
     onClick?: (event?: React.MouseEvent<HTMLElement>) => void,
-    isCollapsible: boolean = true,
+    isCollapsible?: boolean,
     maxItems: number = DEFAULT_MAX_ITEMS,
 ): JSX.Element[] => {
-    let breadcrumbItems: JSX.Element[] = [];
+    const breadcrumbItems: JSX.Element[] = [];
     const collapsedItems: JSX.Element[] = [];
     items.forEach((item, index) => {
-        if (index !== items.length - 1) {
-            if (isCollapsible && items.length > maxItems) {
-                if ([0, items.length - 2].includes(index)) {
-                    breadcrumbItems = [
-                        ...breadcrumbItems,
-                        <Breadcrumb.Item
-                            key={index}
-                            data-qa={item?.dataqa}
-                            href={item?.path}
-                            active={item?.isActive}
-                            onClick={(event?: React.MouseEvent<HTMLElement>) => {
-                                onClick && onClick(event);
-                            }}
-                        >
-                            {<span>{item?.title}</span>}
-                        </Breadcrumb.Item>,
-                    ];
-                } else {
-                    collapsedItems.push(<a href={item?.path}>{item?.title}</a>);
-                }
-            } else {
-                breadcrumbItems.push(
-                    <Breadcrumb.Item
-                        key={index}
-                        data-qa={item?.dataqa}
-                        href={item?.path}
-                        active={item?.isActive}
-                        onClick={(event?: React.MouseEvent<HTMLElement>) => {
-                            onClick && onClick(event);
-                        }}
-                    >
-                        {<span>{item?.title}</span>}
-                    </Breadcrumb.Item>,
-                );
-            }
+        if (index === items.length - 1) return;
+
+        if (isCollapsible && items.length > maxItems && ![0, items.length - 2].includes(index)) {
+            collapsedItems.push(
+                <a href={item?.path} key={item?.path}>
+                    {item?.title}
+                </a>,
+            );
+        } else {
+            breadcrumbItems.push(
+                <Breadcrumb.Item
+                    key={index}
+                    data-qa={item?.dataqa}
+                    href={item?.path}
+                    active={item?.isActive}
+                    onClick={(event?: React.MouseEvent<HTMLElement>) => {
+                        onClick?.(event);
+                    }}
+                >
+                    <span>{item?.title}</span>
+                </Breadcrumb.Item>,
+            );
         }
     });
     items.length > maxItems &&
@@ -95,11 +83,11 @@ const getBreadcrumbItems = (
         breadcrumbItems.splice(
             1,
             0,
-            <div className="breadcrumb-item-container">
+            <div className="breadcrumb-item-container" key="breadcrumb-item-container">
                 <Button className="breadcrumb-item">
                     <Icon
                         shape="ellipsis-horizontal"
-                        data-qa="breadcrumb-collapsed-ellipsis"
+                        data-qa="dataqa-breadcrumb-collapsed-ellipsis"
                         className="breadcrumb-collapsed-ellipsis"
                     />
                 </Button>
@@ -116,13 +104,11 @@ export const Breadcrumbs = ({
     onClick,
     maxItems,
     isCollapsible,
-}: BreadcrumbItems) => {
-    return (
-        <div className={`breadcrumbs-container ${className}`}>
-            <Breadcrumb data-qa={dataqa}>
-                {getBreadcrumbItems(breadcrumbItems, onClick, isCollapsible, maxItems)}
-            </Breadcrumb>
-            <div className="breadcrumb active-element">{breadcrumbItems[breadcrumbItems.length - 1]?.title}</div>
-        </div>
-    );
-};
+}: BreadcrumbItems) => (
+    <div className={`breadcrumbs-container ${className}`}>
+        <Breadcrumb data-qa={dataqa}>
+            {getBreadcrumbItems(breadcrumbItems, onClick, isCollapsible, maxItems)}
+        </Breadcrumb>
+        <div className="breadcrumb active-element">{breadcrumbItems[breadcrumbItems.length - 1]?.title}</div>
+    </div>
+);

--- a/src/components/breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb.tsx
@@ -8,7 +8,8 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import {ReactNode} from "react";
+import {Button} from "@dellstorage/clarity-react/forms/button";
+import {Icon} from "@dellstorage/clarity-react/icon";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
 
 /**
@@ -22,6 +23,7 @@ export type BreadcrumbItem = {
     title: JSX.Element | string;
     path: string;
     isActive?: boolean;
+    maxItems?: number;
     dataqa?: string;
 };
 
@@ -37,37 +39,78 @@ export type BreadcrumbItems = {
     className?: string;
     dataqa?: string;
     onClick?: (event?: React.MouseEvent<HTMLElement>) => void;
+    maxItems?: number;
 };
+
+const DEFAULT_MAX_ITEMS = 3;
 
 const getBreadcrumbItems = (
     items: Array<BreadcrumbItem>,
     onClick?: (event?: React.MouseEvent<HTMLElement>) => void,
+    maxItems?: number,
 ): JSX.Element[] => {
     let breadcrumbItems: JSX.Element[] = [];
+    const collapsedItems: JSX.Element[] = [];
     items.forEach((item, index) => {
         if (index !== items.length - 1) {
-            breadcrumbItems.push(
-                <Breadcrumb.Item
-                    key={index}
-                    data-qa={item?.dataqa}
-                    href={item?.path}
-                    active={item?.isActive}
-                    onClick={(event?: React.MouseEvent<HTMLElement>) => {
-                        onClick && onClick(event);
-                    }}
-                >
-                    {<span>{item?.title}</span>}
-                </Breadcrumb.Item>,
-            );
+            if (items.length > (maxItems || DEFAULT_MAX_ITEMS)) {
+                if ([0, items.length - 2].includes(index)) {
+                    breadcrumbItems = [
+                        ...breadcrumbItems,
+                        <Breadcrumb.Item
+                            key={index}
+                            data-qa={item?.dataqa}
+                            href={item?.path}
+                            active={item?.isActive}
+                            onClick={(event?: React.MouseEvent<HTMLElement>) => {
+                                onClick && onClick(event);
+                            }}
+                        >
+                            {<span>{item?.title}</span>}
+                        </Breadcrumb.Item>,
+                    ];
+                } else {
+                    collapsedItems.push(<a href={item?.path}>{item?.title}</a>);
+                }
+            } else {
+                breadcrumbItems.push(
+                    <Breadcrumb.Item
+                        key={index}
+                        data-qa={item?.dataqa}
+                        href={item?.path}
+                        active={item?.isActive}
+                        onClick={(event?: React.MouseEvent<HTMLElement>) => {
+                            onClick && onClick(event);
+                        }}
+                    >
+                        {<span>{item?.title}</span>}
+                    </Breadcrumb.Item>,
+                );
+            }
         }
     });
+    items.length > (maxItems || DEFAULT_MAX_ITEMS) &&
+        breadcrumbItems.splice(
+            1,
+            0,
+            <div className="breadcrumb-item-container">
+                <Button className="breadcrumb-item">
+                    <Icon
+                        shape="ellipsis-horizontal"
+                        data-qa="breadcrumb-collapsed-ellipsis"
+                        className="breadcrumb-collapsed-ellipsis"
+                    />
+                </Button>
+                <div className="breadcrumb-collapsed-menu">{collapsedItems}</div>
+            </div>,
+        );
     return breadcrumbItems;
 };
 
-export const Breadcrumbs = ({breadcrumbItems = [], className, dataqa, onClick}: BreadcrumbItems) => {
+export const Breadcrumbs = ({breadcrumbItems = [], className, dataqa, onClick, maxItems}: BreadcrumbItems) => {
     return (
         <div className={`breadcrumbs-container ${className}`}>
-            <Breadcrumb data-qa={dataqa}>{getBreadcrumbItems(breadcrumbItems, onClick)}</Breadcrumb>
+            <Breadcrumb data-qa={dataqa}>{getBreadcrumbItems(breadcrumbItems, onClick, maxItems)}</Breadcrumb>
             <div className="breadcrumb active-element">{breadcrumbItems[breadcrumbItems.length - 1]?.title}</div>
         </div>
     );

--- a/src/components/breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb.tsx
@@ -12,6 +12,8 @@ import {Button} from "@dellstorage/clarity-react/forms/button";
 import {Icon} from "@dellstorage/clarity-react/icon";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
 
+const DEFAULT_MAX_ITEMS = 3;
+
 /**
  * Props for the BreadcrumbItem
  * @param {title} is to get the title of the Breadcrumb Item.(can be string or JSX Element)
@@ -23,7 +25,6 @@ export type BreadcrumbItem = {
     title: JSX.Element | string;
     path: string;
     isActive?: boolean;
-    maxItems?: number;
     dataqa?: string;
 };
 
@@ -40,20 +41,20 @@ export type BreadcrumbItems = {
     dataqa?: string;
     onClick?: (event?: React.MouseEvent<HTMLElement>) => void;
     maxItems?: number;
+    isCollapsible?: boolean;
 };
-
-const DEFAULT_MAX_ITEMS = 3;
 
 const getBreadcrumbItems = (
     items: Array<BreadcrumbItem>,
     onClick?: (event?: React.MouseEvent<HTMLElement>) => void,
-    maxItems?: number,
+    isCollapsible: boolean = true,
+    maxItems: number = DEFAULT_MAX_ITEMS,
 ): JSX.Element[] => {
     let breadcrumbItems: JSX.Element[] = [];
     const collapsedItems: JSX.Element[] = [];
     items.forEach((item, index) => {
         if (index !== items.length - 1) {
-            if (items.length > (maxItems || DEFAULT_MAX_ITEMS)) {
+            if (isCollapsible && items.length > maxItems) {
                 if ([0, items.length - 2].includes(index)) {
                     breadcrumbItems = [
                         ...breadcrumbItems,
@@ -89,7 +90,8 @@ const getBreadcrumbItems = (
             }
         }
     });
-    items.length > (maxItems || DEFAULT_MAX_ITEMS) &&
+    items.length > maxItems &&
+        isCollapsible &&
         breadcrumbItems.splice(
             1,
             0,
@@ -107,10 +109,19 @@ const getBreadcrumbItems = (
     return breadcrumbItems;
 };
 
-export const Breadcrumbs = ({breadcrumbItems = [], className, dataqa, onClick, maxItems}: BreadcrumbItems) => {
+export const Breadcrumbs = ({
+    breadcrumbItems = [],
+    className,
+    dataqa,
+    onClick,
+    maxItems,
+    isCollapsible,
+}: BreadcrumbItems) => {
     return (
         <div className={`breadcrumbs-container ${className}`}>
-            <Breadcrumb data-qa={dataqa}>{getBreadcrumbItems(breadcrumbItems, onClick, maxItems)}</Breadcrumb>
+            <Breadcrumb data-qa={dataqa}>
+                {getBreadcrumbItems(breadcrumbItems, onClick, isCollapsible, maxItems)}
+            </Breadcrumb>
             <div className="breadcrumb active-element">{breadcrumbItems[breadcrumbItems.length - 1]?.title}</div>
         </div>
     );

--- a/src/styles/components/Breadcrumb.scss
+++ b/src/styles/components/Breadcrumb.scss
@@ -13,14 +13,14 @@
 @import "../common/mixins";
 
 .breadcrumbs-container {
-  margin: 24px 0;
+  margin: 1.2rem 0;
 }
 
 .breadcrumb {
   display: flex;
   flex-wrap: wrap;
   width: fit-content;
-  padding: 0 2px;
+  padding: 0 0.1rem;
   margin-bottom: 1rem;
   list-style: none;
 
@@ -45,9 +45,9 @@
       box-shadow: 0 0 10px #e4e4e4;
 
       a {
-        padding: 4px 16px 0;
-        font-size: 14px;
-        height: 32px;
+        padding: 0.2rem 0.8rem 0;
+        font-size: $font-size-7;
+        height: 1.6rem;
         display: block;
         min-width: max-content;
 
@@ -72,22 +72,22 @@
     min-width: unset;
 
     span {
-      font-size: 14px;
-      padding: 0 2px;
+      font-size: $font-size-7;
+      padding: 0 0.1rem;
     }
 
     &::before {
-      font-size: 14px;
+      font-size: $font-size-7;
       float: right;
-      padding: 4px 8px;
+      padding: 0.2rem 0.4rem;
       color: $gray-500;
       content: var(--bs-breadcrumb-divider, "/");
       line-height: initial;
     }
 
     :focus {
-      outline: 2px solid $blue-450;
-      border-radius: 5px;
+      outline: 0.1rem solid $blue-450;
+      border-radius: 0.25rem;
     }
 
     &.active {
@@ -106,8 +106,8 @@
   }
 
   &.active-element {
-    font-size: 24px;
-    padding-top: 12px;
+    font-size: $font-size-24;
+    padding-top: 0.6rem;
     margin: 0;
   }
 }

--- a/src/styles/components/Breadcrumb.scss
+++ b/src/styles/components/Breadcrumb.scss
@@ -8,56 +8,70 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
- @import "../common/colors";
- @import "../common/fonts";
- @import "../common/mixins";
- 
+@import "../common/colors";
+@import "../common/fonts";
+@import "../common/mixins";
+
 .breadcrumbs-container {
   margin: 24px 0;
 }
- .breadcrumb {
-   display: flex;
-   flex-wrap: wrap;
-   width: fit-content;
-   padding: 0 2px;
-   margin-bottom: 1rem;
-   list-style: none;
-   line-height: 1;
 
-  .clr-form-control {
-    margin: 0;
-  }
-  
-  a {
-    position: relative;
-    div {
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  width: fit-content;
+  padding: 0 2px;
+  margin-bottom: 1rem;
+  list-style: none;
+
+  .breadcrumb-item-container {
+    .btn.breadcrumb-item {
+      height: unset !important;
+      border: none;
+      margin: 0;
+
+      .breadcrumb-collapsed-ellipsis {
+        margin-top: 8px;
+      }
+    }
+
+    & .breadcrumb-collapsed-menu {
       display: none;
       position: absolute;
       background-color: #fff;
       box-shadow: 0 0 10px #e4e4e4;
-      option {
-        padding: 0 16px;
+
+      a {
+        padding: 4px 16px 0;
         font-size: 14px;
         height: 32px;
-        padding-top: 4px;
+        display: block;
+        min-width: max-content;
+
         &:hover {
           background-color: $gray-100;
           color: $gray-700 !important;
+
         }
         &:active {
           background-color: $blue-50;
         }
       }
     }
+
+    &:focus-within .breadcrumb-collapsed-menu {
+        display: block;
+    }
   }
 
   .breadcrumb-item {
-     padding: 0;
-     min-width: 40px;
-     span {
-       font-size: 14px;
-       padding: 0 2px;
-     }
+    padding: 0;
+    min-width: unset;
+
+    span {
+      font-size: 14px;
+      padding: 0 2px;
+    }
 
     &::before {
       font-size: 14px;
@@ -80,10 +94,6 @@
       }
     }
 
-    .breadcrumb-collapsed-ellipsis {
-      width: 30px;
-    }
-
     @include breadcrumb-item($blue-600);
 
     :hover {
@@ -95,5 +105,5 @@
     font-size: 24px;
     padding-top: 12px;
     margin: 0;
- }
+  }
 }

--- a/src/styles/components/Breadcrumb.scss
+++ b/src/styles/components/Breadcrumb.scss
@@ -33,7 +33,7 @@
       border: none;
       height: unset !important;
 
-      :hover {
+      &:hover {
         background-color: transparent;
       }
     }

--- a/src/styles/components/Breadcrumb.scss
+++ b/src/styles/components/Breadcrumb.scss
@@ -26,12 +26,15 @@
 
   .breadcrumb-item-container {
     .btn.breadcrumb-item {
-      height: unset !important;
-      border: none;
+      display: flex;
+      flex-direction: row-reverse;
+      align-items: flex-end;
       margin: 0;
+      border: none;
+      height: unset !important;
 
-      .breadcrumb-collapsed-ellipsis {
-        margin-top: 8px;
+      :hover {
+        background-color: transparent;
       }
     }
 
@@ -76,9 +79,10 @@
     &::before {
       font-size: 14px;
       float: right;
-      padding: 1px 8px;
+      padding: 4px 8px;
       color: $gray-500;
       content: var(--bs-breadcrumb-divider, "/");
+      line-height: initial;
     }
 
     :focus {


### PR DESCRIPTION
## Descriptions
Implementation of Collapsible breadcrumbs functionality
#### Props added:
##### isCollapsible:
- Check if the breadcrumbs should be collapsible or not
- Default: True
- If set to false, full breadcrumbs list is shown 
![image](https://user-images.githubusercontent.com/78294852/224257921-525bc49f-dde9-47fd-aa87-dfd480949677.png)
##### maxItems:
- Max breadcrumb items count, if breadcrumb count passes this threshold, breadcrumb body truncates into collapsed form 
- Default: 3
- If _isCollapsible_ is false, The effect of maxItems gets inhibited
![image](https://user-images.githubusercontent.com/78294852/224259071-6991822a-3e6f-4b3b-8eb0-8967518b79b9.png)
<hr >
![image](https://user-images.githubusercontent.com/78294852/224258672-cf4e9382-3ad4-4a95-af95-de8b40148308.png)

### Test Environment
http://10.249.253.4:6006/?path=/story/breadcrumb--default-breadcrumbs
