### PR TITLE
[OBSDEF-46589] Bump version to 0.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dellstorage/dell-design-react-common",
   "description": "Override CSS of Clarity-React components to align it with Dell design standards",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "license": "Apache-2.0",
   "private": false,
   "outDir": "dist",
@@ -12,7 +12,7 @@
     "node": ">=16.14.1"
   },
   "dependencies": {
-    "@dellstorage/clarity-react": "^1.2.1",
+    "@dellstorage/clarity-react": "^1.2.12",
     "@types/node": "^12.14.1",
     "bootstrap": "^5.2.0",
     "react": "^17.0.2",


### PR DESCRIPTION
This PR is to bump version to 0.2.9 and update clarity react version
Please refer - 
https://jira.cec.lab.emc.com/browse/OBSDEF-46589
https://jira.cec.lab.emc.com/browse/OBSDEF-46383

Storybook link - http://10.199.196.186:6006/